### PR TITLE
Always output a valid score for MAL

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,7 +112,7 @@ def getAnilistData():
       statusLists {
         progress
         progressVolumes
-        score
+        score(format: POINT_10)
         status
         notes
         repeat


### PR DESCRIPTION
Scores on MyAnimeList always go from 1 to 10.
So when I tried to upload my list with scores that use the 100 points format MAL went *kaboom*.

Luckily, the GraphQL API can convert the scores for us and it should work for all of Anilist's scoring systems.

Anyway, thanks for the script, I thought it would be way harder to update my MAL account ^^"